### PR TITLE
Fix length of yav in interpolation method

### DIFF
--- a/brukeropusreader/opus_data.py
+++ b/brukeropusreader/opus_data.py
@@ -17,7 +17,7 @@ class OpusData(dict):
 
     def interpolate(self, start, stop, num, spec_name="AB"):
         xav = self.get_range(spec_name=spec_name)
-        yav = self[spec_name]
+        yav = self[spec_name][0:len(xav)]
         iwave_nums = np.linspace(start, stop, num)
         f2 = interp1d(xav, yav, kind="cubic", fill_value="extrapolate")
         return iwave_nums, f2(iwave_nums)


### PR DESCRIPTION
As already mentioned in the example ([https://github.com/qedsoftware/brukeropusreader/blob/master/example.py](https://github.com/qedsoftware/brukeropusreader/blob/master/example.py)), the data can contain more Null values at the end. Therefore, `yav` needs to be subsetted in order to match the length of `xav`. Otherwise `interp1d` will throw an error. 