### PR TITLE
Supporting .0 files from ALPHA FTIRs

### DIFF
--- a/brukeropusreader/block_data.py
+++ b/brukeropusreader/block_data.py
@@ -20,6 +20,7 @@ BLOCK_0 = defaultdict(
 )
 
 BLOCK_7 = {
+    0: "Raw0",
     4: "ScSm",
     8: "IgSm",
     12: "PhSm",
@@ -34,6 +35,7 @@ BLOCK_11 = {
 }
 
 BLOCK_23 = {
+    0: "Raw0 Data Parameter",
     4: "ScSm Data Parameter",
     8: "IgSm Data Parameter",
     12: "PhSm Data Parameter",

--- a/brukeropusreader/block_parser.py
+++ b/brukeropusreader/block_parser.py
@@ -53,10 +53,8 @@ def parse_text(data: bytes, block_meta):
 def _parse_raw0(chunk: bytes):
     arr = []
     for i in range(0, len(chunk), 8):
-        arr.append(
-            unpack("<xh3xh", chunk[i : i + 8])[::-1]
-            + tuple(chunk[i + 4] & m for m in RAW0_FLAGS)
-        )
+        adc, flags, xa = unpack("<xhxBxh", chunk[i : i + 8])
+        arr.append((xa, adc) + tuple(bool(flags & m) for m in RAW0_FLAGS))
     return arr
 
 

--- a/brukeropusreader/constants.py
+++ b/brukeropusreader/constants.py
@@ -11,3 +11,9 @@ META_BLOCK_SIZE = 12
 ENCODING_LATIN = "latin-1"
 ENCODING_UTF = "utf-8"
 PARAM_TYPES = {0: "int", 1: "float", 2: "str", 3: "str", 4: "str"}
+RAW0_TYPES = {
+    "names": ["XA", "ADC", "OVF", "FWD", "DQEna", "CPLsw", "XAOVF", "XAValid", "XA External Valid"],
+    "formats": ["i2"] * 2 + ["?"] * 7,
+}
+# XXX Only confirmed masks so far are: FWD, CPLsw, XAValid
+RAW0_FLAGS = [0x20, 0x10, 0x08, 0x04, 0x02, 0x01, 0x40]


### PR DESCRIPTION
So, I happened to get my hand on a packet capture between OPUS and an ALPHA II...
During a scan, OPUS will poll for `.0` files that represent a scan made by the hardware.

As far as I know, no tool out there including `opusFC` parses this specific "Raw 0" file.

I'm sharing this so that others can possibly have a look and chime in to complete what I started. I do not have a copy of OPUS and don't want to dig any further myself.

Some notes:
- Name of the columns comes directly from OPUS as the file is basically just tabular data.
- As mentioned in a comment, the only flags I have confirmed to be in their actual position are FWD, CPLsw, XAValid. The rest is guesswork on what seems the most likely.
Unsure about the meaning of each one, however.
- The first byte of each row looks like a boolean. Unsure what it does.
- The fourth byte looks like sign extension of the ADC
- The sixth byte seems to follow the first one. If the first one is `0x01`, this one is `0x40`. If it's `0x00`, this one is the same.

ADC is interferogram data. No idea what XA is for.